### PR TITLE
:lipstick: Category UI 420px에서 깨지는 현상 수정

### DIFF
--- a/src/components/Category/CategoryMain.jsx
+++ b/src/components/Category/CategoryMain.jsx
@@ -88,16 +88,17 @@ const CategoryMainPage = styled.section`
 `;
 
 const AssortContainer = styled.section`
-  position: relative;
+  height: 883px;
   display: flex;
+  position: relative;
   overflow: scroll;
   padding-right: 20px;
   .assortwrap {
-    background-color: ${COLOR.top};
     display: flex;
+    padding-top: 100px;
+    background-color: ${COLOR.top};
     gap: 20px 0;
     flex-direction: column;
-    padding-top: 100px;
   }
   .listCont {
     width: 250px;

--- a/src/components/Category/PriceCategory.jsx
+++ b/src/components/Category/PriceCategory.jsx
@@ -349,7 +349,7 @@ const AssortPage = styled.section`
   width: 100vw;
   list-style: none;
   position: relative;
-  top: -170px;
+  top: -156px;
   padding: 100px;
   background-color: #fff;
   .cartegory-card {


### PR DESCRIPTION
## 수정 사항 요약 📍

-  Category UI 420px에서 깨지는 현상 수정

## 수정 사항 구체적인 설명

### 아래와 같이 UI 가 깨지는 현상이 발생했습니다.

<img width="202" alt="스크린샷 2022-04-24 오후 4 09 46" src="https://user-images.githubusercontent.com/93380732/164964246-2b6dc3e8-85ac-4629-a43c-0cf3043a3c4d.png">
<img height="300" alt="스크린샷 2022-04-24 오후 4 09 34" src="https://user-images.githubusercontent.com/93380732/164964314-fc67ae91-35d5-4918-a8dc-b8df9caec153.png">



## 체크 리스트 ✅

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
